### PR TITLE
Change the composer vendor namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "symfony/code-block-checker",
+    "name": "symfony-tools/code-block-checker",
     "type": "project",
     "license": "proprietary",
     "require": {


### PR DESCRIPTION
This reflects the name of the organization, and avoids confusing it with official symfony packages.