### PR TITLE
Verify PHP classes

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -3,6 +3,7 @@
 $finder = PhpCsFixer\Finder::create()
     ->in(__DIR__.'/src')
     ->in(__DIR__.'/tests')
+    ->notPath(__DIR__.'/tests/Fixtures')
 ;
 
 return PhpCsFixer\Config::create()

--- a/.php_cs
+++ b/.php_cs
@@ -3,7 +3,6 @@
 $finder = PhpCsFixer\Finder::create()
     ->in(__DIR__.'/src')
     ->in(__DIR__.'/tests')
-    ->notPath(__DIR__.'/tests/Fixtures')
 ;
 
 return PhpCsFixer\Config::create()

--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
     "repositories": [
         {
             "type": "git",
-            "url": "https://github.com/weaverryan/docs-builder"
+            "url": "https://github.com/symfony-tools/docs-builder"
         }
     ],
     "minimum-stability": "dev",

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -10,8 +10,9 @@ services:
 
     _instanceof:
         SymfonyTools\CodeBlockChecker\Service\CodeValidator\Validator:
-            tags:
-                - 'app.code_validator'
+            tags: ['app.code_validator']
+        SymfonyTools\CodeBlockChecker\Service\CodeRunner\Runner:
+            tags: ['app.code_runner']
 
     SymfonyTools\CodeBlockChecker\:
         resource: '../src/'
@@ -21,3 +22,6 @@ services:
 
     SymfonyTools\CodeBlockChecker\Service\CodeValidator:
         arguments: [!tagged_iterator app.code_validator]
+
+    Symfony\CodeBlockChecker\Service\CodeRunner:
+        arguments: [!tagged_iterator app.code_runner]

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -23,5 +23,5 @@ services:
     SymfonyTools\CodeBlockChecker\Service\CodeValidator:
         arguments: [!tagged_iterator app.code_validator]
 
-    Symfony\CodeBlockChecker\Service\CodeRunner:
+    SymfonyTools\CodeBlockChecker\Service\CodeRunner:
         arguments: [!tagged_iterator app.code_runner]

--- a/src/Command/CheckDocsCommand.php
+++ b/src/Command/CheckDocsCommand.php
@@ -22,7 +22,7 @@ use SymfonyDocsBuilder\BuildConfig;
 use SymfonyTools\CodeBlockChecker\Issue\IssueCollection;
 use SymfonyTools\CodeBlockChecker\Listener\CodeNodeCollector;
 use SymfonyTools\CodeBlockChecker\Service\Baseline;
-use SymfonyTools\CodeBlockChecker\Service\CodeNodeRunner;
+use SymfonyTools\CodeBlockChecker\Service\CodeRunner;
 use SymfonyTools\CodeBlockChecker\Service\CodeValidator;
 
 class CheckDocsCommand extends Command

--- a/src/Command/CheckDocsCommand.php
+++ b/src/Command/CheckDocsCommand.php
@@ -34,14 +34,14 @@ class CheckDocsCommand extends Command
     private CodeNodeCollector $collector;
     private CodeValidator $validator;
     private Baseline $baseline;
-    private CodeNodeRunner $codeNodeRunner;
+    private CodeRunner $codeRunner;
 
-    public function __construct(CodeValidator $validator, Baseline $baseline, CodeNodeRunner $codeNodeRunner)
+    public function __construct(CodeValidator $validator, Baseline $baseline, CodeRunner $codeRunner)
     {
         parent::__construct(self::$defaultName);
         $this->validator = $validator;
         $this->baseline = $baseline;
-        $this->codeNodeRunner = $codeNodeRunner;
+        $this->codeRunner = $codeRunner;
     }
 
     protected function configure()
@@ -88,7 +88,7 @@ class CheckDocsCommand extends Command
         // Verify code blocks
         $issues = $this->validator->validateNodes($this->collector->getNodes());
         if ($applicationDir = $input->getOption('symfony-application')) {
-            $issues->append($this->codeNodeRunner->runNodes($this->collector->getNodes(), $applicationDir));
+            $issues->append($this->codeRunner->runNodes($this->collector->getNodes(), $applicationDir));
         }
 
         if ($baselineFile = $input->getOption('generate-baseline')) {

--- a/src/Service/CodeRunner.php
+++ b/src/Service/CodeRunner.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Symfony\CodeBlockChecker\Service;
+namespace SymfonyTools\CodeBlockChecker\Service;
 
 use Doctrine\RST\Nodes\CodeNode;
-use Symfony\CodeBlockChecker\Issue\IssueCollection;
-use Symfony\CodeBlockChecker\Service\CodeRunner\Runner;
+use SymfonyTools\CodeBlockChecker\Issue\IssueCollection;
+use SymfonyTools\CodeBlockChecker\Service\CodeRunner\Runner;
 
 /**
  * Run a Code Node inside a real application.

--- a/src/Service/CodeRunner.php
+++ b/src/Service/CodeRunner.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\CodeBlockChecker\Service;
+
+use Doctrine\RST\Nodes\CodeNode;
+use Symfony\CodeBlockChecker\Issue\IssueCollection;
+use Symfony\CodeBlockChecker\Service\CodeRunner\Runner;
+
+/**
+ * Run a Code Node inside a real application.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class CodeRunner
+{
+    /**
+     * @var iterable<Runner>
+     */
+    private $runners;
+
+    /**
+     * @param iterable<Runner> $runners
+     */
+    public function __construct(iterable $runners)
+    {
+        $this->runners = $runners;
+    }
+
+    /**
+     * @param list<CodeNode> $nodes
+     */
+    public function runNodes(array $nodes, string $applicationDirectory): IssueCollection
+    {
+        $issues = new IssueCollection();
+        foreach ($this->runners as $runner) {
+            $runner->run($nodes, $issues, $applicationDirectory);
+        }
+
+        return $issues;
+    }
+}

--- a/src/Service/CodeRunner/ClassExist.php
+++ b/src/Service/CodeRunner/ClassExist.php
@@ -3,9 +3,9 @@
 namespace SymfonyTools\CodeBlockChecker\Service\CodeRunner;
 
 use Doctrine\RST\Nodes\CodeNode;
+use Symfony\Component\Process\Process;
 use SymfonyTools\CodeBlockChecker\Issue\Issue;
 use SymfonyTools\CodeBlockChecker\Issue\IssueCollection;
-use Symfony\Component\Process\Process;
 
 /**
  * Verify that any reference to a PHP class is actually a real class.

--- a/src/Service/CodeRunner/ClassExist.php
+++ b/src/Service/CodeRunner/ClassExist.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Symfony\CodeBlockChecker\Service\CodeRunner;
+
+use Doctrine\RST\Nodes\CodeNode;
+use Symfony\CodeBlockChecker\Issue\Issue;
+use Symfony\CodeBlockChecker\Issue\IssueCollection;
+use Symfony\Component\Process\Process;
+
+/**
+ * Verify that any reference to a PHP class is actually a real class.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class ClassExist implements Runner
+{
+    /**
+     * @param list<CodeNode> $nodes
+     */
+    public function run(array $nodes, IssueCollection $issues, string $applicationDirectory): void
+    {
+        $classes = [];
+        foreach ($nodes as $node) {
+            $classes = array_merge($classes, $this->getClasses($node));
+        }
+
+        $this->testClasses($classes, $issues, $applicationDirectory);
+    }
+
+    private function getClasses(CodeNode $node): array
+    {
+        $language = $node->getLanguage() ?? 'php';
+        if (!in_array($language, ['php', 'php-symfony', 'php-standalone', 'php-annotations'])) {
+            return [];
+        }
+
+        $classes = [];
+        foreach (explode("\n", $node->getValue()) as $i => $line) {
+            $matches = [];
+            if (0 !== strpos($line, 'use ') || !preg_match('|^use (.*\\\.*); *?$|m', $line, $matches)) {
+                continue;
+            }
+
+            $class = $matches[1];
+            if (false !== $pos = strpos($class, ' as ')) {
+                $class = substr($class, 0, $pos);
+            }
+
+            if (false !== $pos = strpos($class, 'function ')) {
+                continue;
+            }
+
+            $explode = explode('\\', $class);
+            if (
+                'App' === $explode[0] || 'Acme' === $explode[0]
+                || (3 === count($explode) && 'Symfony' === $explode[0] && ('Component' === $explode[1] || 'Config' === $explode[1]))
+            ) {
+                continue;
+            }
+
+            $classes[] = ['class' => $class, 'line' => $i + 1, 'node' => $node];
+        }
+
+        return $classes;
+    }
+
+    /**
+     * Make sure PHP classes exists in the application directory.
+     *
+     * @param array{int, array{ class: string, line: int, node: CodeNode } } $classes
+     */
+    private function testClasses(array $classes, IssueCollection $issues, string $applicationDirectory): void
+    {
+        $fileBody = '';
+        foreach ($classes as $i => $data) {
+            $fileBody .= sprintf('%s => isLoaded("%s"),', $i, $data['class'])."\n";
+        }
+
+        file_put_contents($applicationDirectory.'/class_exist.php', strtr('<?php
+require __DIR__.\'/vendor/autoload.php\';
+
+function isLoaded($class) {
+    return class_exists($class) || interface_exists($class) || trait_exists($class);
+}
+
+echo json_encode([ARRAY_CONTENT]);
+
+', ['ARRAY_CONTENT' => $fileBody]));
+
+        $process = new Process(['php', 'class_exist.php'], $applicationDirectory);
+        $process->run();
+
+        if (!$process->isSuccessful()) {
+            // TODO handle this
+            return;
+        }
+
+        $output = $process->getOutput();
+        try {
+            $results = json_decode($output, true, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            // TODO handle this
+            return;
+        }
+
+        foreach ($classes as $i => $data) {
+            if (!$results[$i]) {
+                $text = sprintf('Class, interface or trait with name "%s" does not exist', $data['class']);
+                $issues->addIssue(new Issue($data['node'], $text, 'Missing class', $data['node']->getEnvironment()->getCurrentFileName(), $data['line']));
+            }
+        }
+    }
+}

--- a/src/Service/CodeRunner/ClassExist.php
+++ b/src/Service/CodeRunner/ClassExist.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Symfony\CodeBlockChecker\Service\CodeRunner;
+namespace SymfonyTools\CodeBlockChecker\Service\CodeRunner;
 
 use Doctrine\RST\Nodes\CodeNode;
-use Symfony\CodeBlockChecker\Issue\Issue;
-use Symfony\CodeBlockChecker\Issue\IssueCollection;
+use SymfonyTools\CodeBlockChecker\Issue\Issue;
+use SymfonyTools\CodeBlockChecker\Issue\IssueCollection;
 use Symfony\Component\Process\Process;
 
 /**

--- a/src/Service/CodeRunner/Runner.php
+++ b/src/Service/CodeRunner/Runner.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Symfony\CodeBlockChecker\Service\CodeRunner;
+namespace SymfonyTools\CodeBlockChecker\Service\CodeRunner;
 
 use Doctrine\RST\Nodes\CodeNode;
-use Symfony\CodeBlockChecker\Issue\IssueCollection;
+use SymfonyTools\CodeBlockChecker\Issue\IssueCollection;
 
 interface Runner
 {

--- a/src/Service/CodeRunner/Runner.php
+++ b/src/Service/CodeRunner/Runner.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Symfony\CodeBlockChecker\Service\CodeRunner;
+
+use Doctrine\RST\Nodes\CodeNode;
+use Symfony\CodeBlockChecker\Issue\IssueCollection;
+
+interface Runner
+{
+    /**
+     * @param list<CodeNode> $nodes
+     */
+    public function run(array $nodes, IssueCollection $issues, string $applicationDirectory): void;
+}

--- a/src/Service/CodeValidator.php
+++ b/src/Service/CodeValidator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace SymfonyTools\CodeBlockChecker\Service;
 
+use Doctrine\RST\Nodes\CodeNode;
 use SymfonyTools\CodeBlockChecker\Issue\IssueCollection;
 use SymfonyTools\CodeBlockChecker\Service\CodeValidator\Validator;
 
@@ -27,6 +28,9 @@ class CodeValidator
         $this->validators = $validators;
     }
 
+    /**
+     * @param list<CodeNode> $nodes
+     */
     public function validateNodes(array $nodes): IssueCollection
     {
         $issues = new IssueCollection();

--- a/tests/Fixtures/example-application/.gitignore
+++ b/tests/Fixtures/example-application/.gitignore
@@ -1,0 +1,1 @@
+class_exist.php

--- a/tests/Fixtures/example-application/composer.json
+++ b/tests/Fixtures/example-application/composer.json
@@ -1,0 +1,11 @@
+{
+    "name": "example/app",
+    "type": "project",
+    "license": "MIT",
+    "require": {},
+    "autoload": {
+        "psr-4": {
+            "Example\\App\\": "src/"
+        }
+    }
+}

--- a/tests/Fixtures/example-application/src/Foobar.php
+++ b/tests/Fixtures/example-application/src/Foobar.php
@@ -4,5 +4,4 @@ namespace Example\App;
 
 class Foobar
 {
-
 }

--- a/tests/Fixtures/example-application/src/Foobar.php
+++ b/tests/Fixtures/example-application/src/Foobar.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Example\App;
+
+class Foobar
+{
+
+}

--- a/tests/Fixtures/example-application/vendor/autoload.php
+++ b/tests/Fixtures/example-application/vendor/autoload.php
@@ -1,0 +1,7 @@
+<?php
+
+// Fake autoloader.
+
+foreach (glob(__DIR__.'/../src/**') as $path) {
+    require_once $path;
+}

--- a/tests/Service/CodeRunner/BaseCodeRunnerTest.php
+++ b/tests/Service/CodeRunner/BaseCodeRunnerTest.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace SymfonyTools\CodeBlockChecker\Tests\Service\CodeRunner;
+
+use PHPUnit\Framework\TestCase;
+
+abstract class BaseCodeRunnerTest extends TestCase
+{
+    protected function getApplicationDirectory(): string
+    {
+        return dirname(__DIR__, 2).'/Fixtures/example-application';
+    }
+}

--- a/tests/Service/CodeRunner/ClassExistTest.php
+++ b/tests/Service/CodeRunner/ClassExistTest.php
@@ -1,0 +1,47 @@
+<?php
+
+
+namespace SymfonyTools\CodeBlockChecker\Tests\Service\CodeRunner;
+
+
+use Doctrine\RST\Configuration;
+use Doctrine\RST\Environment;
+use Doctrine\RST\Nodes\CodeNode;
+use SymfonyTools\CodeBlockChecker\Issue\IssueCollection;
+use SymfonyTools\CodeBlockChecker\Service\CodeRunner\ClassExist;
+use SymfonyTools\CodeBlockChecker\Service\CodeRunner\Runner;
+use SymfonyTools\CodeBlockChecker\Service\CodeValidator\PhpValidator;
+use SymfonyTools\CodeBlockChecker\Service\CodeValidator\Validator;
+
+class ClassExistTest extends BaseCodeRunnerTest
+{
+    private Runner $runner;
+    private Environment $environment;
+
+    protected function setUp(): void
+    {
+        $this->environment = new Environment(new Configuration());
+        $this->runner = new ClassExist();
+    }
+    public function testHappyPath()
+    {
+        $code = '
+use Example\App\Foobar;
+use Symfony\Component\HttpKernel;
+use Foo\Bar\Baz;
+
+echo "hello";
+';
+        $node = new CodeNode(explode(PHP_EOL, $code));
+        $node->setEnvironment($this->environment);
+        $node->setLanguage('php');
+        $issues = new IssueCollection();
+        $this->runner->run([$node], $issues, $this->getApplicationDirectory());
+        $this->assertCount(1, $issues);
+
+        $issue = $issues->first();
+        $this->assertStringContainsString('Foo\Bar\Baz', $issue->getText());
+    }
+
+
+}

--- a/tests/Service/CodeRunner/ClassExistTest.php
+++ b/tests/Service/CodeRunner/ClassExistTest.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace SymfonyTools\CodeBlockChecker\Tests\Service\CodeRunner;
-
 
 use Doctrine\RST\Configuration;
 use Doctrine\RST\Environment;
@@ -10,8 +8,6 @@ use Doctrine\RST\Nodes\CodeNode;
 use SymfonyTools\CodeBlockChecker\Issue\IssueCollection;
 use SymfonyTools\CodeBlockChecker\Service\CodeRunner\ClassExist;
 use SymfonyTools\CodeBlockChecker\Service\CodeRunner\Runner;
-use SymfonyTools\CodeBlockChecker\Service\CodeValidator\PhpValidator;
-use SymfonyTools\CodeBlockChecker\Service\CodeValidator\Validator;
 
 class ClassExistTest extends BaseCodeRunnerTest
 {
@@ -23,6 +19,7 @@ class ClassExistTest extends BaseCodeRunnerTest
         $this->environment = new Environment(new Configuration());
         $this->runner = new ClassExist();
     }
+
     public function testHappyPath()
     {
         $code = '
@@ -42,6 +39,4 @@ echo "hello";
         $issue = $issues->first();
         $this->assertStringContainsString('Foo\Bar\Baz', $issue->getText());
     }
-
-
 }


### PR DESCRIPTION
Make sure that each reference to a PHP class (in a PHP code block) is to a class that exists. 

This code is not pretty. One could extend this to verify PHP classes referenced in XML code blocks too. 