### PR TITLE
Bunch of fixes for PHP and Twig parsing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "symfony/flex": "^1.3.1",
         "symfony/framework-bundle": "^5.2",
         "symfony/process": "^5.2",
+        "symfony/twig-bridge": "^5.4",
         "symfony/yaml": "^5.2",
         "twig/twig": "^3.3"
     },

--- a/src/Service/CodeValidator/PhpValidator.php
+++ b/src/Service/CodeValidator/PhpValidator.php
@@ -51,7 +51,7 @@ class PhpValidator implements Validator
         }
 
         // Allow us to use "..." as a placeholder
-        $contents = str_replace(['...,', '...)', '...;', '...]'], ['null,', 'null)', 'null;', 'null]'], $contents);
+        $contents = str_replace(['...,', '...)', '...;', '...]', '... }'], ['null,', 'null)', 'null;', 'null]', '$a = null; }'], $contents);
 
         $lines = explode("\n", $contents);
         if (!str_contains($lines[0] ?? '', '<?php') && !str_contains($lines[1] ?? '', '<?php') && !str_contains($lines[2] ?? '', '<?php')) {

--- a/src/Service/CodeValidator/PhpValidator.php
+++ b/src/Service/CodeValidator/PhpValidator.php
@@ -41,8 +41,13 @@ class PhpValidator implements Validator
     private function getContents(CodeNode $node, &$linesPrepended = null): string
     {
         $contents = $node->getValue();
-        if (!preg_match('#(class|interface) [a-zA-Z]+#s', $contents) && preg_match('#(public|protected|private)( static)? (\$[a-z]+|function)#s', $contents)) {
-            $contents = 'class Foobar {'.$contents.'}';
+        if (
+            !preg_match('#(class|interface) [a-zA-Z]+#s', $contents)
+            && !preg_match('#= new class#s', $contents)
+            && preg_match('#(public|protected|private)( static)? (\$[a-z]+|function).*#s', $contents, $matches)
+        ) {
+            // keep "uses" and other code before the class definition
+            $contents = substr($contents, 0, strpos($contents, $matches[1])).PHP_EOL.'class Foobar {'.$matches[0].'}';
         }
 
         // Allow us to use "..." as a placeholder

--- a/src/Twig/DummyExtension.php
+++ b/src/Twig/DummyExtension.php
@@ -2,9 +2,15 @@
 
 namespace SymfonyTools\CodeBlockChecker\Twig;
 
+use Symfony\Bridge\Twig\TokenParser\DumpTokenParser;
+use Symfony\Bridge\Twig\TokenParser\FormThemeTokenParser;
+use Symfony\Bridge\Twig\TokenParser\StopwatchTokenParser;
+use Symfony\Bridge\Twig\TokenParser\TransDefaultDomainTokenParser;
+use Symfony\Bridge\Twig\TokenParser\TransTokenParser;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
 use Twig\TwigFunction;
+use Twig\TwigTest;
 
 /**
  * This extension will contain filters and functions that exists in Symfony. This
@@ -91,6 +97,27 @@ class DummyExtension extends AbstractExtension
             new TwigFilter('markdown_to_html'),
             new TwigFilter('inky_to_html'),
             new TwigFilter('serialize'),
+            new TwigFilter('price'),
+            new TwigFilter('greet'),
+        ];
+    }
+
+    public function getTests()
+    {
+        return [
+            new TwigTest('rootform'),
+            new TwigTest('selectedchoice'),
+        ];
+    }
+
+    public function getTokenParsers()
+    {
+        return [
+            new DumpTokenParser(),
+            new FormThemeTokenParser(),
+            new StopwatchTokenParser(false),
+            new TransTokenParser(),
+            new TransDefaultDomainTokenParser(),
         ];
     }
 }


### PR DESCRIPTION
Summary of my attempt to run the script locally against 4.4 version of the docs:

 * ~99e66e28390efa39043f2f88e0cf11f33beb42b3: temporary commits error logs (__134__ in total)~ // Removed
 * 13be7acc3bc82dd3d6add239b52388c81631126e: fix PHP code that is inlined in `class { ... }` context (only 2 errors fixed)
 * c7164fb89744f05c661e2a162add4899e409d89b: add missing Twig features (21 errors fixed!)
 * 25945c2175f03a5c18c622603549559529771e7d + https://github.com/symfony/symfony-docs/pull/16868/commits/f396e09371718847f54994d32182b3fb0f96ea91: fix ellipsis (9 erros fixed)