### PR TITLE
Use the same Yaml Parser flags as in Symfony

### DIFF
--- a/src/Service/CodeValidator/YamlValidator.php
+++ b/src/Service/CodeValidator/YamlValidator.php
@@ -19,7 +19,7 @@ class YamlValidator implements Validator
         // Allow us to use "..." as a placeholder
         $contents = str_replace('...', 'null', $node->getValue());
         try {
-            Yaml::parse($contents, Yaml::PARSE_CUSTOM_TAGS);
+            Yaml::parse($contents, Yaml::PARSE_CONSTANT | Yaml::PARSE_CUSTOM_TAGS);
         } catch (ParseException $e) {
             if ('Duplicate key' === substr($e->getMessage(), 0, 13)) {
                 return;


### PR DESCRIPTION
Following a correction suggestion in documentation, I realized that the Yaml parser was not configured with the same options as in Symfony's YamlFileLoader. Therefore, this PR adds the Yaml::PARSE_CONSTANT flag to the Parser.

Reference: https://github.com/symfony/symfony/blob/6.4/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php#L778