### PR TITLE
Provide more precission about the syntax errors location

### DIFF
--- a/src/Command/CheckDocsCommand.php
+++ b/src/Command/CheckDocsCommand.php
@@ -141,7 +141,7 @@ class CheckDocsCommand extends Command
             foreach ($files as $i => $file) {
                 if (!file_exists($sourceDirectory.DIRECTORY_SEPARATOR.$file)) {
                     unset($files[$i]);
-                    $this->outputWarning($input->getOption('output-format'), sprintf('Could not find file "%s"', $file));
+                    $this->outputNotice($input->getOption('output-format'), sprintf('Skipping "%s" (file does not exist)', $file));
                 }
             }
         }
@@ -159,12 +159,12 @@ class CheckDocsCommand extends Command
         return $parseQueue;
     }
 
-    private function outputWarning(string $format, string $text): void
+    private function outputNotice(string $format, string $text): void
     {
         if ('console' === $format) {
-            $this->io->warning($text);
+            $this->io->note($text);
         } elseif ('github' === $format) {
-            $this->io->writeln('::warning::'.$text);
+            $this->io->writeln('::notice::'.$text);
         }
     }
 
@@ -180,7 +180,7 @@ class CheckDocsCommand extends Command
             foreach ($issues as $issue) {
                 // We use urlencoded '\n'
                 $text = str_replace(PHP_EOL, '%0A', $issue->getText());
-                $this->io->writeln(sprintf('::error file=%s,line=%s::[%s] %s', $issue->getFile(), $issue->getLine(), $issue->getType(), $text));
+                $this->io->writeln(sprintf('::error file=%s,line=%s::[%s] %s (in %s on line %d)', $issue->getFile(), $issue->getLine(), $issue->getType(), $text, $issue->getFile(), $issue->getLine()));
             }
         }
     }

--- a/src/Service/CodeValidator/PhpValidator.php
+++ b/src/Service/CodeValidator/PhpValidator.php
@@ -53,6 +53,9 @@ class PhpValidator implements Validator
         // Allow us to use "..." as a placeholder
         $contents = str_replace(['...,', '...)', '...;', '...]', '... }'], ['null,', 'null)', 'null;', 'null]', '$a = null; }'], $contents);
 
+        // Allow us to use "= /* some placeholder */;" as a placeholder value
+        $contents = preg_replace('#=[ \t]*/\*.*?\*/[ \t]*;#', '= null;', $contents);
+
         $lines = explode("\n", $contents);
         if (!str_contains($lines[0], '<?php') && !str_contains($lines[1] ?? '', '<?php') && !str_contains($lines[2] ?? '', '<?php')) {
             $contents = '<?php'."\n".$contents;

--- a/tests/Service/Validator/PhpValidatorTest.php
+++ b/tests/Service/Validator/PhpValidatorTest.php
@@ -107,6 +107,17 @@ public static function validate($object, ExecutionContextInterface $context, $pa
 }
 '];
         yield [0, '
+$this->connection = /* create your connection */;
+$id = /* get the message id thanks to information or stamps present in the envelope */;
+'];
+        yield [1, '
+$x = ;
+'];
+        yield [1, '
+$x =
+    /* a multi-line placeholder is not rewritten, to preserve line numbers */;
+'];
+        yield [0, '
 <h1>Hello</h1>
 <p><? echo $value; ?></p>
 ', 'html+php'];


### PR DESCRIPTION
Fixes #58. It includes 3 fixes:

* Missing files (e.g. when we delete files because we're merging docs) now show a notice instead of a warning. So, we won't miss them, but they don't produce an error on GitHub.
* Provide precise location (file + line number) of syntax errors
* In addition to `= ...` support a comment placeholder like `$foo = /* some text here */;`